### PR TITLE
Fix wrapping

### DIFF
--- a/R/cross_validate.R
+++ b/R/cross_validate.R
@@ -35,7 +35,7 @@ cross_validate <- function(cv_fun,
     wrapped_fun <- wrap_in_try(cv_fun)
     
     # main loop
-    results <- future_lapply(folds, wrapped_fun, ...)
+    results <- future_lapply(folds, wrapped_fun, ..., future.globals=FALSE)
 
     # remove error results
     error_idx <- which(sapply(results, inherits, "try-error"))

--- a/R/cross_validate.R
+++ b/R/cross_validate.R
@@ -31,8 +31,11 @@ cross_validate <- function(cv_fun,
                            .combine_control = list(),
                            .old_results = NULL) {
 
+    #catch and return errors if they occur
+    wrapped_fun <- wrap_in_try(cv_fun)
+    
     # main loop
-    results <- future_lapply(folds, safe_eval, fun = cv_fun, ...)
+    results <- future_lapply(folds, wrapped_fun, ...)
 
     # remove error results
     error_idx <- which(sapply(results, inherits, "try-error"))

--- a/R/utils.R
+++ b/R/utils.R
@@ -9,3 +9,14 @@ safe_eval <- function(fun, ...) {
         fun(...)
     }, silent = TRUE)
 }
+
+# replicate foreach error collection
+# function factory that generates wrapped version of functions
+wrap_in_try <- function(fun, ...) {
+    wrapped <- function(...)
+    try({
+        fun(...)
+    }, silent = TRUE)
+    
+    return(wrapped)
+}


### PR DESCRIPTION
Fix an issue related to how we wrap cv_functions functions to catch errors. There is some weirdness with how futures scrapes the global environment that I don't currently understand. I'll need to write some tests specifically related to this soon.